### PR TITLE
Update formatting of NIC management in stateless

### DIFF
--- a/stateless.7.rst
+++ b/stateless.7.rst
@@ -263,10 +263,11 @@ Since the connectivity could be lost during the procedure, physical access to th
 system is required. To switch to NetworkManager for all the interfaces, the
 user should disable and stop systemd-networkd:
 
-    ``sudo systemctl disable systemd-networkd``
-    ``sudo systemctl stop systemd-networkd``
+    ``sudo systemctl disable systemd-networkd && sudo systemctl stop systemd-networkd``
 
-Then, remove the file ``/etc/NetworkManager/conf.d/systemd-networkd-unmanaged.conf``
+Then, remove the systemd-networkd-unmanaged.conf file:
+
+    ``sudo rm /etc/NetworkManager/conf.d/systemd-networkd-unmanaged.conf``
 
 Finally, restart NetworkManager
 


### PR DESCRIPTION
Two minor formatting changing the Network interface management section of the stateless page.

- The two systemctl commands do not render on new line in the compiled man file without a line break. A single like with && is cleaner.
- Change the second action to remove the file to an actual `sudo rm` command, to match the other two actions being provided a commands.